### PR TITLE
CS-1275: add support to set permission at organization level

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This module will create following resources:
 * You need to have the following privileges to apply the configuration
   * Organization Administrator
   * IAM Workload Identity Pool Admin (at Org level)
-  * Service Account Admin (at Host Project level)
+  * Service Account Admin (at Org level)
 
 ### 2. Terraform
 
@@ -65,7 +65,7 @@ module "create-gcp-cred" {
   # Copy Uptycs's AWS Account ID and Role from Uptycs' UI.
   # Uptycs' UI: "Cloud"->"GCP"->"Integrations"->"ORGANIZATION INTEGRATION"
   host_aws_account_id     = "<AWS account id>"
-  host_aws_instance_roles  = ["<Role1>", "<Role2>", "<Role3>"]
+  host_aws_instance_roles  = ["Role_Allinone", "Role_PNode", "Role_Cloudquery"]
 }
 
 output "host-project-id" {
@@ -99,7 +99,7 @@ If you set the flag `set_org_level_permissions` to true, then the permissions at
 | host_project_id           | GCP Project ID that Uptycs should create required resources under     | `string`       | Required                |
 | host_aws_account_id       | AWS account id of Uptycs - for federated identity                     | `string`       | Required                |
 | host_aws_instance_roles   | AWS role names of Uptycs - for identity binding                       | `list(string)` | Required                |
-| set_org_level_permissions | The flag to choose permissions at organization level or project level | `bool`         | Required                |
+| set_org_level_permissions | The flag to choose permissions at organization level or project level | `bool`         | true                |
 
 #### Outputs
 

--- a/README.md
+++ b/README.md
@@ -1,41 +1,52 @@
-# Terraform GCP module - Organization Integration for Uptycs 
+# Terraform GCP module - Organization Integration for Uptycs
 
 ## Overview
+
 This module will provision the required GCP resources inorder to integrate GCP organization with Uptycs.
 
 This will module will integrate multiple child projects under the organization.
 
 This module will create following resources:
- * Service Account, Workload Identity Pool & Identity provider under host-project
- * For each project selected, it will add IAM read permissions (described below) so Uptycs can collect telemetry
- * Read permissions for the created Service Account
-     * roles/iam.securityReviewer
-     * roles/bigquery.resourceViewer
-     * roles/pubsub.subscriber
-     * roles/viewer
+
+* Service Account, Workload Identity Pool & Identity provider under host-project
+* For each project selected or for all projects in the Organization, it will add IAM read permissions (described below) so Uptycs can collect telemetry
+* Read permissions for the created Service Account
+  * roles/iam.securityReviewer
+  * roles/bigquery.resourceViewer
+  * roles/pubsub.subscriber
+  * roles/viewer
+  * roles/browser
 
 ## Requirements
+
 ### 1. User & IAM
+
 * You need to have the following privileges to apply the configuration
-    * Organization Administrator
-    * IAM Workload Identity Pool Admin (at Org level)
-    * Service Account Admin (at Host Project level)
+  * Organization Administrator
+  * IAM Workload Identity Pool Admin (at Org level)
+  * Service Account Admin (at Host Project level)
 
 ### 2. Terraform
+
 `terraform` version >= 1.2.5
 
 ### 3. gcloud CLI
+
 `gcloud` is required to get authenticated and to generate credentials file
 
-### 4. Authenticate 
+### 4. Authenticate
+
 ```
 Login with ADC
   - "gcloud auth application-default login"
 ```
+
 ## Terraform script
 
 ### 1. Prepare .tf file
-  * Create a `main.tf` file in a new folder. Paste following configuration and modify as needed.
+
+* Create a `main.tf` file in a new folder. Paste following configuration and modify as needed.
+
 ```
 module "create-gcp-cred" {
   source                    = "github.com/uptycslabs/terraform-google-gcp-integration"
@@ -46,11 +57,15 @@ module "create-gcp-cred" {
   # Select an existing project from your organization to host resources created by this configuration
   host_project_id = "<Host-Project-ID>"
 
+  # Set to true, If you want to give permission at organization level
+  # Set to false, If you want to give permissions at project level
+  set_org_level_permissions = true
+
   # AWS account details
   # Copy Uptycs's AWS Account ID and Role from Uptycs' UI.
   # Uptycs' UI: "Cloud"->"GCP"->"Integrations"->"ORGANIZATION INTEGRATION"
   host_aws_account_id     = "<AWS account id>"
-  host_aws_instance_roles  = ["<Role1>", "<Role2>"]
+  host_aws_instance_roles  = ["<Role1>", "<Role2>", "<Role3>"]
 }
 
 output "host-project-id" {
@@ -66,23 +81,33 @@ output "credential-file-gen-command" {
 }
 
 ```
+
+#### Note
+
+If you set the flag `set_org_level_permissions` to true, then the permissions at organization level will be attached to the service account, so that you don't need to execute `step 2` for every addition of new project.
+
 ### 2. Init, Plan and Apply
 
 #### Inputs
-| Name                      | Description                                                          | Type          | Default          |
-| ------------------------- | -------------------------------------------------------------------- | ------------- | ---------------- |
-| organization_id           | The GCP parent organizations id where resources will be created.     | `string`      | Required         |
-| integration_name          | Unique phrase. Used to name resources                                | `string`      | `"uptycs-int-20220101"`|
-| service_account_name      | The service account name which will be created in host project.      | `string`      | `"sa-for-uptycs"`|
-| host_project_id           | GCP Project ID that Uptycs should create required resources under    | `string`      | Required         |
-| host_aws_account_id       | AWS account id of Uptycs - for federated identity                    | `string`      | Required         |
-| host_aws_instance_roles   | AWS role names of Uptycs - for identity binding                      | `list(string)`| Required         |
+
+
+| Name                      | Description                                                           | Type           | Default                 |
+| --------------------------- | ----------------------------------------------------------------------- | ---------------- | ------------------------- |
+| organization_id           | The GCP parent organizations id where resources will be created.      | `string`       | Required                |
+| integration_name          | Unique phrase. Used to name resources                                 | `string`       | `"uptycs-int-20220101"` |
+| service_account_name      | The service account name which will be created in host project.       | `string`       | `"sa-for-uptycs"`       |
+| host_project_id           | GCP Project ID that Uptycs should create required resources under     | `string`       | Required                |
+| host_aws_account_id       | AWS account id of Uptycs - for federated identity                     | `string`       | Required                |
+| host_aws_instance_roles   | AWS role names of Uptycs - for identity binding                       | `list(string)` | Required                |
+| set_org_level_permissions | The flag to choose permissions at organization level or project level | `bool`         | Required                |
 
 #### Outputs
-| Name                            | Description                                  |
-| ------------------------------- | -------------------------------------------- |
-| credential-file-gen-command     | Command to generate credentials JSON file.   |
-| host-project-id                 | Host Project ID.                             |
+
+
+| Name                        | Description                                |
+| ----------------------------- | -------------------------------------------- |
+| credential-file-gen-command | Command to generate credentials JSON file. |
+| host-project-id             | Host Project ID.                           |
 
 ```
 $ terraform init
@@ -92,9 +117,10 @@ $ terraform apply
 ```
 
 ### Notes
+
 1. Change `integration_name` to change names of the resources host folder, project, wip and idp.
 2. Notes on `terraform destroy`
-     - Soft-deleted provider can be restored using `UndeleteWorkloadIdentityPoolProvider`.
-     - ID cannot be re-used until the WIP is permanently deleted.
-     - Same WIP can't be created again.
-4. Run the command returned by `credential-file-gen-command` to re-generate `credentials.json`
+   - Soft-deleted provider can be restored using `UndeleteWorkloadIdentityPoolProvider`.
+   - ID cannot be re-used until the WIP is permanently deleted.
+   - Same WIP can't be created again.
+3. Run the command returned by `credential-file-gen-command` to re-generate `credentials.json`

--- a/main.tf
+++ b/main.tf
@@ -36,22 +36,54 @@ resource "google_service_account" "sa_for_hostproject" {
 }
 
 resource "google_project_iam_member" "bind_viewer_SA_to_filter_projects" {
-  for_each   = local.projects_to_integrate
+  for_each   = var.set_org_level_permissions == true ? [] : local.projects_to_integrate
   project    = each.key
   role       = "roles/viewer"
 
   member     = "serviceAccount:${google_service_account.sa_for_hostproject.email}"
 }
 
-resource "google_organization_iam_member" "bind_projects_browser_SA_to_filter_projects" {
+resource "google_organization_iam_member" "bind_projects_browser_SA_to_Organization" {
   org_id    = var.organization_id
   role       = "roles/browser"
 
   member     = "serviceAccount:${google_service_account.sa_for_hostproject.email}"
 }
 
+resource "google_organization_iam_member" "bind_Viewer_SA_to_Organization" {
+  count = var.set_org_level_permissions == true ? 1 : 0
+  org_id    = var.organization_id
+  role       = "roles/viewer"
+
+  member     = "serviceAccount:${google_service_account.sa_for_hostproject.email}"
+}
+
+resource "google_organization_iam_member" "bind_resourceViewer_SA_to_Organization" {
+  count = var.set_org_level_permissions == true ? 1 : 0
+  org_id    = var.organization_id
+  role       = "roles/bigquery.resourceViewer"
+
+  member     = "serviceAccount:${google_service_account.sa_for_hostproject.email}"
+}
+
+resource "google_organization_iam_member" "bind_pubsub_SA_to_Organization" {
+  count = var.set_org_level_permissions == true ? 1 : 0
+  org_id    = var.organization_id
+  role       = "roles/pubsub.subscriber"
+
+  member     = "serviceAccount:${google_service_account.sa_for_hostproject.email}"
+}
+
+resource "google_organization_iam_member" "bind_securityReviewer_SA_to_Organization" {
+  count = var.set_org_level_permissions == true ? 1 : 0
+  org_id    = var.organization_id
+  role       = "roles/iam.securityReviewer"
+
+  member     = "serviceAccount:${google_service_account.sa_for_hostproject.email}"
+}
+
 resource "google_project_iam_member" "bind_resourceViewer_SA_to_filter_projects" {
-  for_each   = local.projects_to_integrate
+  for_each   = var.set_org_level_permissions == true ? [] : local.projects_to_integrate
   project    = each.key
   role       = "roles/bigquery.resourceViewer"
 
@@ -60,7 +92,7 @@ resource "google_project_iam_member" "bind_resourceViewer_SA_to_filter_projects"
 }
 
 resource "google_project_iam_member" "bind_pubsub_SA_to_filter_projects" {
-  for_each   = local.projects_to_integrate
+  for_each   = var.set_org_level_permissions == true ? [] : local.projects_to_integrate
   project    = each.key
   role       = "roles/pubsub.subscriber"
 
@@ -68,7 +100,7 @@ resource "google_project_iam_member" "bind_pubsub_SA_to_filter_projects" {
 }
 
 resource "google_project_iam_member" "bind_securityReviewer_SA_to_filter_projects" {
-  for_each   = local.projects_to_integrate
+  for_each   = var.set_org_level_permissions == true ? [] : local.projects_to_integrate
   project    = each.key
   role       = "roles/iam.securityReviewer"
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,11 @@ variable "integration_name" {
   description = "Unique tag. Used to name resources created by the plan"
 }
 
+variable "set_org_level_permissions" {
+  type = bool
+  description = "Used to set permissions at org level or project level"
+}
+
 variable "service_account_name" {
   type = string
   description = "The GCP service account name."


### PR DESCRIPTION
Added a flag support to choose addition of permissions between organization level and project level. If permissions set at organization level, we can avoid rerun of terraform when new projects got added