### PR TITLE
GCP Org Integration on Windows machine remove interpreter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,6 @@ resource "google_service_account_iam_binding" "workload_identity_binding" {
 resource "null_resource" "cred_config_json" {
   provisioner "local-exec" {
     command     = "gcloud iam workload-identity-pools create-cred-config projects/${data.google_project.my_host_project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.create_wip.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.add_provider.workload_identity_pool_provider_id} --service-account=${google_service_account.sa_for_hostproject.email} --output-file=credentials.json --aws"
-    interpreter = ["/bin/sh", "-c"]
   }
   depends_on = [google_service_account_iam_binding.workload_identity_binding]
 }


### PR DESCRIPTION
Removed line 147 which assigned interpreter. Appropriate interpreter auto-assigned based on OS.