### PR TITLE
CSM-13310: Allow local-exec skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ To execute the Terraform script:
      # Uptycs' UI: "Cloud"->"GCP"->"Integrations"->"ORGANIZATION INTEGRATION"
      host_aws_account_id     = "<AWS account id>"
      host_aws_instance_roles  = ["Role_Allinone", "Role_PNode", "Role_Cloudquery"]
+   
+     # AWS account details
+     # Set this to skip execution of local commands like "gcloud"
+     skip_local_exec = false
    }
 
    output "host-project-id" {
@@ -87,7 +91,7 @@ To execute the Terraform script:
 
 
    | Name                      | Description                                                           | Type           | Default                 |
-   | ------------------------- | --------------------------------------------------------------------- | -------------- | ----------------------- |
+---------------------------| ------------------------- | --------------------------------------------------------------------- | -------------- | ----------------------- |
    | organization_id           | The GCP parent organization ID where resources are created            | `string`       | Required                |
    | integration_name          | Unique phrase used to name the resources                              | `string`       | `"uptycs-int-20220101"` |
    | service_account_name      | The service account name that is created in the host project          | `string`       | `"sa-for-uptycs"`       |
@@ -95,6 +99,7 @@ To execute the Terraform script:
    | host_aws_account_id       | AWS account ID of Uptycs - for federated identity                     | `string`       | Required                |
    | host_aws_instance_roles   | AWS role names of Uptycs - for identity binding                       | `list(string)` | Required                |
    | set_org_level_permissions | The flag to choose permissions at organization level or project level | `bool`         | true                    |
+   | skip_local_exec           | Flag to skip local command execution                                  | `bool`         | false                   |
 
    **Outputs**
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ To execute the Terraform script:
      host_aws_account_id     = "<AWS account id>"
      host_aws_instance_roles  = ["Role_Allinone", "Role_PNode", "Role_Cloudquery"]
    
-     # AWS account details
      # Set this to skip execution of local commands like "gcloud"
+     # If set to 'true', credential JSON file must be created outside of TF. Uptycs needs the credentials JSON file.
+     # Please refer to the TF output for "gcloud" that can generate the credentials JSON file
      skip_local_exec = false
    }
 
@@ -89,20 +90,18 @@ To execute the Terraform script:
 
    **Inputs**
 
-
-   | Name                      | Description                                                           | Type           | Default                 |
----------------------------| ------------------------- | --------------------------------------------------------------------- | -------------- | ----------------------- |
-   | organization_id           | The GCP parent organization ID where resources are created            | `string`       | Required                |
-   | integration_name          | Unique phrase used to name the resources                              | `string`       | `"uptycs-int-20220101"` |
-   | service_account_name      | The service account name that is created in the host project          | `string`       | `"sa-for-uptycs"`       |
-   | host_project_id           | GCP Project ID under which Uptycs should create required resources    | `string`       | Required                |
-   | host_aws_account_id       | AWS account ID of Uptycs - for federated identity                     | `string`       | Required                |
-   | host_aws_instance_roles   | AWS role names of Uptycs - for identity binding                       | `list(string)` | Required                |
-   | set_org_level_permissions | The flag to choose permissions at organization level or project level | `bool`         | true                    |
-   | skip_local_exec           | Flag to skip local command execution                                  | `bool`         | false                   |
+   | Name                      | Description                                                           | Type                                                                  | Default                                                               |
+   |---------------------------|-----------------------------------------------------------------------|-----------------------------------------------------------------------|-----------------------------------------------------------------------|
+   | organization_id           | The GCP parent organization ID where resources are created            | `string`                                                              | Required                                                              |
+   | integration_name          | Unique phrase used to name the resources                              | `string`                                                              | `"uptycs-int-20220101"`                                               |
+   | service_account_name      | The service account name that is created in the host project          | `string`                                                              | `"sa-for-uptycs"`                                                     |
+   | host_project_id           | GCP Project ID under which Uptycs should create required resources    | `string`                                                              | Required                                                              |
+   | host_aws_account_id       | AWS account ID of Uptycs - for federated identity                     | `string`                                                              | Required                                                              |
+   | host_aws_instance_roles   | AWS role names of Uptycs - for identity binding                       | `list(string)`                                                        | Required                                                              |
+   | set_org_level_permissions | The flag to choose permissions at organization level or project level | `bool`                                                                | true                                                                  |
+   | skip_local_exec           | Flag to skip local command execution                                  | `bool`                                                                | false                                                                 |
 
    **Outputs**
-
 
    | Name                        | Description                                |
    | ----------------------------- | -------------------------------------------- |

--- a/main.tf
+++ b/main.tf
@@ -142,6 +142,7 @@ resource "google_service_account_iam_binding" "workload_identity_binding" {
 }
 
 resource "null_resource" "cred_config_json" {
+  count = var.skip_local_exec == true ? 0 : 1
   provisioner "local-exec" {
     command     = "gcloud iam workload-identity-pools create-cred-config projects/${data.google_project.my_host_project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.create_wip.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.add_provider.workload_identity_pool_provider_id} --service-account=${google_service_account.sa_for_hostproject.email} --output-file=credentials.json --aws"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -33,3 +33,8 @@ variable "host_aws_instance_roles" {
   description = "AWS roles of Uptycs - for identity binding."
 }
 
+variable "skip_local_exec" {
+  type = bool
+  default = false
+  description = "Set this to true to skip executing local commands like gcloud"
+}


### PR DESCRIPTION
Allow skipping local exec so module does't depend on executing local commands like `gcloud`

Tested the following cases
 - [x] Leave new var to default
 - [x] Set `skip_local_exec = true`  and make sure it doest run `gcloud`
 - [x] Set `skip_local_exec = false`  and make sure it runs `gcloud`